### PR TITLE
chore: add react-server-components eslint rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@cloudscape-design/build-tools",
       "version": "3.0.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^10.0.1"
+      },
       "devDependencies": {
         "@types/node": "^20.0.0",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
@@ -1497,6 +1500,22 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.6.0.tgz",
@@ -1981,14 +2000,12 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -4888,15 +4905,15 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -6661,6 +6678,22 @@
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "postbuild": "cp package.json NOTICE README.md LICENSE lib",
     "test": "vitest run"
   },
+  "dependencies": {
+    "minimatch": "^10.0.1"
+  },
   "peerDependencies": {
     "stylelint": "^16.8.1"
   },

--- a/src/eslint/__tests__/react-server-components-directive.test.js
+++ b/src/eslint/__tests__/react-server-components-directive.test.js
@@ -1,0 +1,139 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { describe, test } from "vitest";
+import { RuleTester } from "eslint";
+import rscDirective from "../react-server-components-directive.js";
+
+const testRule = testCase => {
+  new RuleTester({ parserOptions: { ecmaVersion: 2018, sourceType: "module" } }).run(
+    "react-server-components-directive",
+    rscDirective,
+    { valid: [], invalid: [], ...testCase },
+  );
+};
+
+describe("valid", () => {
+  test("directive is not needed on internal files", () => {
+    testRule({
+      valid: [
+        {
+          code: "export default function InternalButton() {}",
+          filename: "./src/button/internal.tsx",
+        },
+      ],
+    });
+  });
+
+  test("directive works on index.tsx files", () =>
+    testRule({
+      valid: [
+        {
+          code: `
+            "use client";
+            export default function Button() {}
+          `,
+          filename: "./src/button/index.tsx",
+        },
+      ],
+    }));
+
+  test("directive works on index.ts files", () =>
+    testRule({
+      valid: [
+        {
+          code: `
+            "use client";
+            export default function Tooltip() {}
+          `,
+          filename: "./src/i18n/index.ts",
+        },
+      ],
+    }));
+
+  test("directive can be set after a license comment", () =>
+    testRule({
+      valid: [
+        {
+          code: `
+            // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+            // SPDX-License-Identifier: Apache-2.0
+            "use client";
+            export default function Button() {}
+          `,
+          filename: "./src/button/index.tsx",
+        },
+      ],
+    }));
+
+  test("entryFilesPattern can be changed", () =>
+    testRule({
+      valid: [
+        {
+          code: `
+            "use client";
+            export default function Tooltip() {}
+          `,
+          filename: "./src/internal/tooltip-do-not-use/index.ts",
+          options: [
+            {
+              entryFilesPattern: "./src/internal/tooltip-do-not-use/index.ts",
+            },
+          ],
+        },
+      ],
+    }));
+});
+
+describe("invalid", () => {
+  test("unexpected directive in an internal file", () =>
+    testRule({
+      invalid: [
+        {
+          code: `
+            "use client";
+            export default function InternalButton() {}
+          `,
+          output: `
+            
+            export default function InternalButton() {}
+          `,
+          filename: "./src/button/internal.tsx",
+          errors: [{ message: 'Unexpected "use client" directive inside an internal file.' }],
+        },
+      ],
+    }));
+
+  test("no directive on a file with a comment", () =>
+    testRule({
+      invalid: [
+        {
+          code: `
+            // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+            // SPDX-License-Identifier: Apache-2.0
+            export default function Button() {}
+          `,
+          output: `
+            // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+            // SPDX-License-Identifier: Apache-2.0
+            "use client";
+export default function Button() {}
+          `,
+          filename: "./src/button/index.tsx",
+          errors: [{ message: 'Missing "use client" directive on the entry file.' }],
+        },
+      ],
+    }));
+
+  test("no directive on a file without a comment", () =>
+    testRule({
+      invalid: [
+        {
+          code: "export default function Button() {}",
+          output: `"use client";
+export default function Button() {}`,
+          filename: "./src/button/index.tsx",
+          errors: [{ message: 'Missing "use client" directive on the entry file.' }],
+        },
+      ],
+    }));
+});

--- a/src/eslint/index.js
+++ b/src/eslint/index.js
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import rscDirective from "./react-server-components-directive.js";
+
+export default {
+  rules: {
+    "react-server-components-directive": rscDirective,
+  },
+};

--- a/src/eslint/react-server-components-directive.js
+++ b/src/eslint/react-server-components-directive.js
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import micromatch from "micromatch";
+import path from "node:path";
+
+export default {
+  meta: {
+    fixable: "code",
+    schema: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          entryFilesPattern: {
+            type: "string",
+          },
+        },
+      },
+    },
+  },
+  create(context) {
+    const entryFilesPattern = path.resolve(context.options[0]?.entryFilesPattern ?? "./src/*/index.{ts,tsx}");
+    const filename = path.resolve(context.filename);
+    const isEntryFile = micromatch.isMatch(filename, entryFilesPattern);
+    return {
+      Program(node) {
+        const useClientDirective = node.body.find(node => node.directive === "use client");
+        if (isEntryFile && !useClientDirective) {
+          context.report({
+            node,
+            message: 'Missing "use client" directive on the entry file.',
+            fix(fixer) {
+              return fixer.insertTextBefore(node.body[0], '"use client";\n');
+            },
+          });
+        }
+        if (!isEntryFile && useClientDirective) {
+          context.report({
+            node,
+            message: 'Unexpected "use client" directive inside an internal file.',
+            fix(fixer) {
+              return fixer.remove(useClientDirective);
+            },
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
### Description

Add eslint rule to validate `"use client"` presence in our code. This rule ensures that all our public components are annotated as client components

Why not using [eslint-plugin-react-server-components](https://github.com/roginfarrer/eslint-plugin-react-server-components)? Because we want to define client-server boundaries statically, once and for all components. We do not need dynamic feature detection for every internal file.


Related links, issue #, if available: n/a

### How has this been tested?

Added unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
