### PR TITLE
feat: building the build tools into /lib

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,15 @@
 {
   "extends": ["eslint:recommended", "plugin:prettier/recommended"],
+  "parser": "@typescript-eslint/parser",
+  "ignorePatterns": ["lib/*"],
   "parserOptions": {
     "ecmaVersion": "latest",
     "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
   },
-  "plugins": ["unicorn", "header"],
+  "plugins": ["unicorn", "header", "@typescript-eslint"],
   "rules": {
     "header/header": [
       "error",
@@ -12,5 +17,7 @@
       [" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.", " SPDX-License-Identifier: Apache-2.0"],
     ],
     "no-warning-comments": "warn",
-  },
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-namespace": "off"
+  }
 }

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+npm run build
+git add lib/
+git commit -m "chore: auto update built files" > /dev/null 2>&1 || true

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
+    "./lib/*": "./lib/*",
     "./*": "./lib/*"
   },
   "repository": {
@@ -14,17 +15,21 @@
   "scripts": {
     "prepare": "husky",
     "lint": "eslint --ignore-path .gitignore --ext js,ts .",
-    "build": "echo 'build skipped'",
+    "prebuild": "rm -rf lib && mkdir lib",
+    "build": "cp -R src/* lib/",
     "test": "vitest run"
   },
   "dependencies": {
+    "lodash": "^4.0.0",
     "minimatch": "^10.0.1"
   },
   "peerDependencies": {
     "stylelint": "^16.8.1"
   },
   "devDependencies": {
+    "@types/lodash": "^4.17.21",
     "@types/node": "^20.19.24",
+    "@types/react": "^16.14.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@vitest/coverage-v8": "^4.0.6",
@@ -40,7 +45,10 @@
     "eslint-plugin-unicorn": "^55.0.0",
     "husky": "^9.1.4",
     "lint-staged": "^15.2.7",
+    "lodash": "^4.17.21",
     "prettier": "^3.3.3",
+    "react": "16.14.0",
+    "typescript": "^5.0.0",
     "vitest": "^4.0.6"
   },
   "lint-staged": {

--- a/src/eslint/__tests__/react-server-components-directive.test.js
+++ b/src/eslint/__tests__/react-server-components-directive.test.js
@@ -1,0 +1,139 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { describe, test } from "vitest";
+import { RuleTester } from "eslint";
+import rscDirective from "../react-server-components-directive.js";
+
+const testRule = testCase => {
+  new RuleTester({ parserOptions: { ecmaVersion: 2018, sourceType: "module" } }).run(
+    "react-server-components-directive",
+    rscDirective,
+    { valid: [], invalid: [], ...testCase },
+  );
+};
+
+describe("valid", () => {
+  test("directive is not needed on internal files", () => {
+    testRule({
+      valid: [
+        {
+          code: "export default function InternalButton() {}",
+          filename: "./src/button/internal.tsx",
+        },
+      ],
+    });
+  });
+
+  test("directive works on index.tsx files", () =>
+    testRule({
+      valid: [
+        {
+          code: `
+            "use client";
+            export default function Button() {}
+          `,
+          filename: "./src/button/index.tsx",
+        },
+      ],
+    }));
+
+  test("directive works on index.ts files", () =>
+    testRule({
+      valid: [
+        {
+          code: `
+            "use client";
+            export default function Tooltip() {}
+          `,
+          filename: "./src/i18n/index.ts",
+        },
+      ],
+    }));
+
+  test("directive can be set after a license comment", () =>
+    testRule({
+      valid: [
+        {
+          code: `
+            // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+            // SPDX-License-Identifier: Apache-2.0
+            "use client";
+            export default function Button() {}
+          `,
+          filename: "./src/button/index.tsx",
+        },
+      ],
+    }));
+
+  test("entryFilesPattern can be changed", () =>
+    testRule({
+      valid: [
+        {
+          code: `
+            "use client";
+            export default function Tooltip() {}
+          `,
+          filename: "./src/internal/tooltip-do-not-use/index.ts",
+          options: [
+            {
+              entryFilesPattern: "./src/internal/tooltip-do-not-use/index.ts",
+            },
+          ],
+        },
+      ],
+    }));
+});
+
+describe("invalid", () => {
+  test("unexpected directive in an internal file", () =>
+    testRule({
+      invalid: [
+        {
+          code: `
+            "use client";
+            export default function InternalButton() {}
+          `,
+          output: `
+            
+            export default function InternalButton() {}
+          `,
+          filename: "./src/button/internal.tsx",
+          errors: [{ message: 'Unexpected "use client" directive inside an internal file.' }],
+        },
+      ],
+    }));
+
+  test("no directive on a file with a comment", () =>
+    testRule({
+      invalid: [
+        {
+          code: `
+            // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+            // SPDX-License-Identifier: Apache-2.0
+            export default function Button() {}
+          `,
+          output: `
+            // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+            // SPDX-License-Identifier: Apache-2.0
+            "use client";
+export default function Button() {}
+          `,
+          filename: "./src/button/index.tsx",
+          errors: [{ message: 'Missing "use client" directive on the entry file.' }],
+        },
+      ],
+    }));
+
+  test("no directive on a file without a comment", () =>
+    testRule({
+      invalid: [
+        {
+          code: "export default function Button() {}",
+          output: `"use client";
+export default function Button() {}`,
+          filename: "./src/button/index.tsx",
+          errors: [{ message: 'Missing "use client" directive on the entry file.' }],
+        },
+      ],
+    }));
+});

--- a/src/eslint/index.js
+++ b/src/eslint/index.js
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import rscDirective from "./react-server-components-directive.js";
+
+export default {
+  rules: {
+    "react-server-components-directive": rscDirective,
+  },
+};

--- a/src/eslint/react-server-components-directive.js
+++ b/src/eslint/react-server-components-directive.js
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import micromatch from "micromatch";
+import path from "node:path";
+
+export default {
+  meta: {
+    fixable: "code",
+    schema: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          entryFilesPattern: {
+            type: "string",
+          },
+        },
+      },
+    },
+  },
+  create(context) {
+    const entryFilesPattern = path.resolve(context.options[0]?.entryFilesPattern ?? "./src/*/index.{ts,tsx}");
+    const filename = path.resolve(context.filename);
+    const isEntryFile = micromatch.isMatch(filename, entryFilesPattern);
+    return {
+      Program(node) {
+        const useClientDirective = node.body.find(node => node.directive === "use client");
+        if (isEntryFile && !useClientDirective) {
+          context.report({
+            node,
+            message: 'Missing "use client" directive on the entry file.',
+            fix(fixer) {
+              return fixer.insertTextBefore(node.body[0], '"use client";\n');
+            },
+          });
+        }
+        if (!isEntryFile && useClientDirective) {
+          context.report({
+            node,
+            message: 'Unexpected "use client" directive inside an internal file.',
+            fix(fixer) {
+              return fixer.remove(useClientDirective);
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/src/stylelint/__tests__/common.js
+++ b/src/stylelint/__tests__/common.js
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { fileURLToPath, URL } from "node:url";
+
+export const configBasedir = fileURLToPath(new URL(".", import.meta.url));

--- a/src/stylelint/__tests__/license-headers.test.js
+++ b/src/stylelint/__tests__/license-headers.test.js
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { describe, test, expect } from "vitest";
+import stylelint from "stylelint";
+
+import { configBasedir } from "./common.js";
+
+function runPlugin(code, header, fix = false) {
+  return stylelint.lint({
+    code,
+    configBasedir,
+    fix,
+    config: {
+      plugins: ["../license-headers.js"],
+      rules: {
+        "@cloudscape-design/license-headers": [true, { header }],
+      },
+    },
+  });
+}
+
+describe("Typical usage", () => {
+  test("finds single line comments", async () => {
+    const { errored } = await runPlugin(
+      `/* My copyright */
+    .some-css {}
+    `,
+      "My copyright",
+    );
+    expect(errored).toBe(false);
+  });
+
+  test("does not find single line comments", async () => {
+    const { errored } = await runPlugin(
+      `/* Different copyright */
+  .some-css {}
+  `,
+      "My copyright",
+    );
+    expect(errored).toBe(true);
+  });
+
+  test("finds multi-line comments", async () => {
+    const { errored } = await runPlugin(
+      `/* My copyright
+ Copyright 2022 */
+.some-css {}
+`,
+      "My copyright\n Copyright 2022",
+    );
+    expect(errored).toBe(false);
+  });
+
+  test("ignores non-root comments", async () => {
+    const { errored } = await runPlugin(
+      `.some-css {}
+/* My copyright */
+  `,
+      "My copyright",
+    );
+    expect(errored).toBe(true);
+  });
+});
+
+describe("Autofixing", () => {
+  test("fixes simple file without header", async () => {
+    const { errored, output } = await runPlugin(`.some-css {}`, "My copyright", true);
+    expect(errored).toBe(false);
+    expect(output).toBe(
+      `/*My copyright*/
+.some-css {}`,
+    );
+  });
+
+  test("fixes file with existing header", async () => {
+    const { errored, output } = await runPlugin(
+      `/* some other header */
+.some-css {}`,
+      "My copyright",
+      true,
+    );
+    expect(errored).toBe(false);
+    expect(output).toBe(
+      `/*My copyright*/
+/* some other header */
+.some-css {}`,
+    );
+  });
+
+  test("does not add duplicate headers", async () => {
+    const input = `/*My copyright*/
+.some-css {}`;
+
+    const { errored, output } = await runPlugin(input, "My copyright", true);
+    expect(errored).toBe(false);
+    expect(output).toBe(input);
+  });
+});

--- a/src/stylelint/__tests__/no-implicit-descendant.test.js
+++ b/src/stylelint/__tests__/no-implicit-descendant.test.js
@@ -1,0 +1,86 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { describe, test, expect } from "vitest";
+import stylelint from "stylelint";
+
+import { configBasedir } from "./common.js";
+
+function runPlugin(code) {
+  return stylelint.lint({
+    code,
+    configBasedir,
+    config: {
+      plugins: ["../no-implicit-descendant.js"],
+      rules: {
+        "@cloudscape-design/no-implicit-descendant": [true, { ignoreParents: [".ignore"] }],
+      },
+    },
+  });
+}
+
+describe("Typical usage", () => {
+  test("should only catch nested selectors", async () => {
+    const { errored } = await runPlugin(".outer {}; .outer2 {}");
+    expect(errored).toBe(false);
+  });
+
+  test("should catch nested css rule with no combinator", async () => {
+    const { errored } = await runPlugin(".outer { .inner {} }");
+    expect(errored).toBe(true);
+  });
+
+  test("should allow nested css rule with an explicit combinator", async () => {
+    const { errored } = await runPlugin(".outer { ~ .sibling {} }");
+    expect(errored).toBe(false);
+  });
+
+  test("should catch nested css rule next to passing css rules", async () => {
+    const { errored } = await runPlugin(".outer { ~ .sibling1, ~ .sibling2, .other {} }");
+    expect(errored).toBe(true);
+  });
+
+  test("should allow pseudoelements without a combinator", async () => {
+    const { errored } = await runPlugin(".outer { &:hover, &:focus {} }");
+    expect(errored).toBe(false);
+  });
+
+  test("should catch nesting in sass mixins", async () => {
+    const { errored } = await runPlugin("@mixin outer { .inner {} }");
+    expect(errored).toBe(true);
+  });
+
+  test('should allow selectors using "&"', async () => {
+    // This is technically a violation, but we let another rule catch this one.
+    const { errored } = await runPlugin(".outer { & inner {} }");
+    expect(errored).toBe(false);
+  });
+});
+
+describe("ignoreParents", () => {
+  test("should allow nested rules under ignored parent", async () => {
+    const { errored } = await runPlugin(".ignore { .inner {} }");
+    expect(errored).toBe(false);
+  });
+
+  test("should allow nested rules under nested ignored parent", async () => {
+    const { errored } = await runPlugin(".outer { > .ignore { .inner {} } }");
+    expect(errored).toBe(false);
+  });
+});
+
+describe("At-rule exemptions", () => {
+  test("should allow nested rules under top-level at-rules", async () => {
+    const { errored } = await runPlugin("@media print { .inner {} }");
+    expect(errored).toBe(false);
+  });
+
+  test("should catch nested rules under nested at-rules", async () => {
+    const { errored } = await runPlugin(".outer { @media print { .inner {} } }");
+    expect(errored).toBe(true);
+  });
+
+  test("should allow nested rules with explicit combinator under nested at-rules", async () => {
+    const { errored } = await runPlugin(".outer { @media print { > .inner {} } }");
+    expect(errored).toBe(false);
+  });
+});

--- a/src/stylelint/__tests__/no-motion-outside-of-mixin.test.js
+++ b/src/stylelint/__tests__/no-motion-outside-of-mixin.test.js
@@ -1,0 +1,122 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { describe, test, expect } from "vitest";
+import stylelint from "stylelint";
+
+import { configBasedir } from "./common.js";
+
+// This is for prettier format: https://github.com/prettier/prettier/issues/2330
+// String.raw is an identity function in this context
+const css = String.raw;
+
+function runPlugin(code) {
+  return stylelint.lint({
+    code,
+    configBasedir,
+    config: {
+      plugins: ["../no-motion-outside-of-mixin.js"],
+      rules: {
+        "@cloudscape-design/no-motion-outside-of-mixin": [true],
+      },
+    },
+  });
+}
+
+describe("No motion outside of mixin", () => {
+  test("should not have errors on a valid code", async () => {
+    const result = await runPlugin(".block { padding: 10px; }");
+    expect(result.results[0].warnings).toEqual([]);
+    expect(result.errored).toBe(false);
+  });
+
+  test("should allow motion inside a keyframes declaration", async () => {
+    const result = await runPlugin(`
+      @keyframes my-keyframes {
+        0% {
+          animation-timing-function: linear
+        } 
+        50% {
+          animation-timing-function: ease-out
+        } 
+      }
+   `);
+    expect(result.results[0].warnings).toEqual([]);
+    expect(result.errored).toBe(false);
+  });
+
+  describe.each(["animation", "transition"])("%s property", property => {
+    test("should allow motion inside of the special mixin", async () => {
+      const result = await runPlugin(css`
+        .styled-circle-motion {
+          @include styles.with-motion {
+            ${property}: my-animation;
+          }
+        }
+      `);
+      expect(result.results[0].warnings).toEqual([]);
+    });
+
+    test("should not allow nested rules inside of the mixin", async () => {
+      const result = await runPlugin(css`
+        .block {
+          @include styles.with-motion {
+            .element {
+              ${property}: my-animation;
+            }
+          }
+        }
+      `);
+      expect(result.errored).toBe(true);
+      expect(result.results[0].warnings.length).toBe(1);
+      expect(result.results[0].warnings).toEqual([
+        expect.objectContaining({
+          rule: "@cloudscape-design/no-motion-outside-of-mixin",
+          severity: "error",
+          text: `Property "${property}" should be directly under 'with-motion' helper (@cloudscape-design/no-motion-outside-of-mixin)`,
+        }),
+      ]);
+      expect(result.errored).toBe(true);
+    });
+
+    test("should not allow motion outside of the mixin", async () => {
+      const result = await runPlugin(`.block { ${property}: my-animation; }`);
+      expect(result.errored).toBe(true);
+      expect(result.results[0].warnings.length).toBe(1);
+      expect(result.results[0].warnings).toEqual([
+        expect.objectContaining({
+          rule: "@cloudscape-design/no-motion-outside-of-mixin",
+          severity: "error",
+          text: `Property "${property}" should be directly under 'with-motion' helper (@cloudscape-design/no-motion-outside-of-mixin)`,
+        }),
+      ]);
+      expect(result.errored).toBe(true);
+    });
+
+    test("should not allow motion if mixin in the scope but not a parent", async () => {
+      const result = await runPlugin(css`
+        .styled-circle-motion {
+          @include styles.with-motion {
+          }
+          ${property}: my-animation;
+        }
+      `);
+      expect(result.results[0].warnings.length).toBe(1);
+      expect(result.results[0].warnings).toEqual([
+        expect.objectContaining({
+          rule: "@cloudscape-design/no-motion-outside-of-mixin",
+          severity: "error",
+          text: `Property "${property}" should be directly under 'with-motion' helper (@cloudscape-design/no-motion-outside-of-mixin)`,
+        }),
+      ]);
+      expect(result.errored).toBe(true);
+    });
+
+    test("should allow sass variable declarations outside mixin", async () => {
+      const result = await runPlugin(css`
+        $element${property}-duration: 300s;
+      `);
+      expect(result.results[0].warnings).toEqual([]);
+      expect(result.errored).toBe(false);
+    });
+  });
+});

--- a/src/stylelint/__tests__/z-index-value-constraint.test.js
+++ b/src/stylelint/__tests__/z-index-value-constraint.test.js
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { describe, test, expect } from "vitest";
+import stylelint from "stylelint";
+
+import { configBasedir } from "./common.js";
+
+// This is for prettier format: https://github.com/prettier/prettier/issues/2330
+// String.raw is an identity function in this context
+const css = String.raw;
+
+function runPlugin(code) {
+  return stylelint.lint({
+    code,
+    configBasedir,
+    config: {
+      plugins: ["../z-index-value-constraint.js"],
+      rules: {
+        "@cloudscape-design/z-index-value-constraint": [true],
+      },
+    },
+  });
+}
+
+describe("z-index value contstraint rule", () => {
+  test("allows non integer z-index values", async () => {
+    const result = await runPlugin(css`
+      .styled-circle-motion {
+        @include styles.with-motion {
+          z-index: some.$variable;
+        }
+      }
+    `);
+
+    expect(result.errored).toBe(false);
+  });
+
+  test.each([0, 1000])("allows non negative z-index values: %s", async zIndexValue => {
+    const result = await runPlugin(css`
+      .styled-circle-motion {
+        @include styles.with-motion {
+          z-index: ${zIndexValue};
+        }
+      }
+    `);
+
+    expect(result.errored).toBe(false);
+  });
+
+  test("does not allow negative z-index values", async () => {
+    const result = await runPlugin(css`
+      .styled-circle-motion {
+        @include styles.with-motion {
+          z-index: -10;
+        }
+      }
+    `);
+
+    expect(result.errored).toBe(true);
+    expect(result.results[0].warnings[0].text).toBe(`Avoid using negative z-index values: -10.
+    This can cause the element to disappear behind its container's background color. (@cloudscape-design/z-index-value-constraint)`);
+  });
+});

--- a/src/stylelint/index.js
+++ b/src/stylelint/index.js
@@ -1,0 +1,8 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import licenseHeaders from "./license-headers.js";
+import noImplicitDescendant from "./no-implicit-descendant.js";
+import noMotionOutsideOfMixin from "./no-motion-outside-of-mixin.js";
+import zIndexValueConstraint from "./z-index-value-constraint.js";
+
+export default [noImplicitDescendant, noMotionOutsideOfMixin, licenseHeaders, zIndexValueConstraint];

--- a/src/stylelint/license-headers.js
+++ b/src/stylelint/license-headers.js
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import stylelint from "stylelint";
+
+const ruleName = "@cloudscape-design/license-headers";
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  rejected: "Missing license header",
+});
+
+function licenseHeadersPlugin(enabled, { header }, context) {
+  if (!enabled) {
+    return;
+  }
+
+  if (!header) {
+    throw new Error(`stylelint ${ruleName} rule requires a header option.`);
+  }
+
+  const trimmedHeader = header.trim();
+
+  return (root, result) => {
+    let foundComment = false;
+    let firstComment = null;
+
+    root.walkComments(function (comment) {
+      if (comment.parent.type === "root" && comment === comment.parent.first) {
+        if (!firstComment) {
+          firstComment = comment;
+        }
+
+        if (comment.text.trim() === trimmedHeader) {
+          foundComment = true;
+        }
+      }
+    });
+
+    if (!foundComment) {
+      if (context.fix) {
+        const newComment = `/*${header}*/\n\n`;
+        root.prepend(newComment);
+      } else {
+        stylelint.utils.report({
+          message: messages.rejected,
+          node: firstComment || root,
+          result,
+          ruleName,
+        });
+      }
+    }
+  };
+}
+
+licenseHeadersPlugin.ruleName = ruleName;
+licenseHeadersPlugin.messages = messages;
+
+export default stylelint.createPlugin(ruleName, licenseHeadersPlugin);

--- a/src/stylelint/no-implicit-descendant.js
+++ b/src/stylelint/no-implicit-descendant.js
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import stylelint from "stylelint";
+
+const ruleName = "@cloudscape-design/no-implicit-descendant";
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  rejected: (parentSelector, selectors) => {
+    return `Avoid nesting without a combinator at ${parentSelector} → ${selectors.join(", ")}`;
+  },
+});
+
+const defaultOptions = {
+  ignoreParents: [],
+};
+
+const removeLeadingCombinators = selector => selector.replace(/^[>+~]\s+/, "");
+
+const getContainerName = container => {
+  if (container.type === "rule") {
+    return container.selector;
+  } else if (container.type === "atrule") {
+    return `@${container.name}`;
+  } else {
+    throw new Error(`Unexpected container type "${container.type}"`);
+  }
+};
+
+function noImplicitDescendantPlugin(enabled, { ignoreParents } = defaultOptions) {
+  if (!enabled) {
+    return;
+  }
+
+  return (root, result) => {
+    root.walkRules(function (rule) {
+      const parent = rule.parent;
+
+      // CSS scoping is not a concern for certain elements (like SVGs).
+      if (
+        parent.type === "rule" &&
+        parent.selectors.every(parentSelector => ignoreParents.includes(removeLeadingCombinators(parentSelector)))
+      ) {
+        return;
+      }
+
+      // We have to check at-rules because SCSS lets us nest at-rules inside other rules.
+      // Top level at-rules are fine, except for @mixin and @include because their actual location is unknown to the parser.
+      if (
+        parent.type === "atrule" &&
+        (ignoreParents.includes(`@${parent.name}`) ||
+          (parent.parent.type === "root" && parent.name !== "mixin" && parent.name !== "include"))
+      ) {
+        return;
+      }
+
+      // Non-nested and space-separated selectors are already covered by the
+      // "selector-combinator-disallowed-list" rule.
+      if (parent.type !== "root") {
+        // Combine comma-separated selectors to reduce output noise.
+        const failingSelectors = rule.selectors.filter(
+          selector => !selector.match(/^[>+~]/) && !selector.includes("&"),
+        );
+
+        if (failingSelectors.length > 0) {
+          stylelint.utils.report({
+            result,
+            ruleName,
+            message: messages.rejected(getContainerName(parent), failingSelectors),
+            node: rule,
+          });
+        }
+      }
+    });
+  };
+}
+noImplicitDescendantPlugin.ruleName = ruleName;
+noImplicitDescendantPlugin.messages = messages;
+
+export default stylelint.createPlugin(ruleName, noImplicitDescendantPlugin);

--- a/src/stylelint/no-motion-outside-of-mixin.js
+++ b/src/stylelint/no-motion-outside-of-mixin.js
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import stylelint from "stylelint";
+
+const ruleName = "@cloudscape-design/no-motion-outside-of-mixin";
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  rejected: property => `Property "${property}" should be directly under 'with-motion' helper`,
+});
+
+function findUpUntil(node, callback) {
+  let current = node;
+  while (current && !callback(current)) {
+    current = current.parent;
+  }
+  return current;
+}
+
+function noMotionOutsideOfMixinPlugin() {
+  return (root, result) => {
+    root.walkDecls(/animation|transition/, decl => {
+      // sass variables are okay, because they do not produce CSS
+      if (decl.prop.startsWith("$")) {
+        return;
+      }
+      const parent = decl.parent;
+      const hasMotionMixin =
+        parent.type === "atrule" && parent.name === "include" && parent.params.endsWith("with-motion");
+      const isInKeyframes = findUpUntil(decl, node => node.type === "atrule" && node.name === "keyframes");
+
+      if (!hasMotionMixin && !isInKeyframes) {
+        stylelint.utils.report({
+          result,
+          ruleName,
+          message: messages.rejected(decl.prop),
+          node: decl,
+        });
+      }
+    });
+  };
+}
+noMotionOutsideOfMixinPlugin.ruleName = ruleName;
+noMotionOutsideOfMixinPlugin.messages = messages;
+
+export default stylelint.createPlugin(ruleName, noMotionOutsideOfMixinPlugin);

--- a/src/stylelint/z-index-value-constraint.js
+++ b/src/stylelint/z-index-value-constraint.js
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import stylelint from "stylelint";
+
+const ruleName = "@cloudscape-design/z-index-value-constraint";
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  noNegativeZIndex: zIndexValue => {
+    return `Avoid using negative z-index values: ${zIndexValue}.
+    This can cause the element to disappear behind its container's background color.`;
+  },
+});
+
+function zIndexValueConstraint(enabled) {
+  if (!enabled) {
+    return;
+  }
+
+  return function (root, result) {
+    root.walkDecls(function (decl) {
+      if (decl.prop !== "z-index") return;
+
+      const zIndexValue = Number(decl.value);
+
+      // If the z-index value is not a number (e.g. variable), don't throw an error.
+      if (Number.isNaN(zIndexValue)) return;
+
+      if (zIndexValue < 0) {
+        stylelint.utils.report({
+          result,
+          ruleName,
+          message: messages.noNegativeZIndex(zIndexValue),
+          node: decl,
+        });
+      }
+    });
+  };
+}
+
+zIndexValueConstraint.ruleName = ruleName;
+zIndexValueConstraint.messages = messages;
+
+export default stylelint.createPlugin(ruleName, zIndexValueConstraint);


### PR DESCRIPTION
### Description
This PR introduces a build process for the build-tools package, enabling distribution from the /lib directory. This change is part 1 of splitting [PR #23](https://github.com/cloudscape-design/build-tools/pull/23) into smaller, reviewable chunks.

Testing:
- by consuming from chat-components and components repository and making sure it doesn't break anything.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
