### PR TITLE
chore: export the dev-pages-utils specifically

### DIFF
--- a/lib/dev-pages-utils/permutations-view.d.ts
+++ b/lib/dev-pages-utils/permutations-view.d.ts
@@ -2,5 +2,6 @@ import React from "react";
 export interface PermutationsViewProps<T> {
     permutations: ReadonlyArray<T>;
     render: (_props: T, _index?: number) => React.ReactElement;
+    direction?: "vertical" | "horizontal";
 }
-export declare function PermutationsView<T>({ permutations, render }: PermutationsViewProps<T>): React.JSX.Element;
+export declare function PermutationsView<T>({ permutations, render, direction }: PermutationsViewProps<T>): React.JSX.Element;

--- a/lib/dev-pages-utils/permutations-view.js
+++ b/lib/dev-pages-utils/permutations-view.js
@@ -15,11 +15,12 @@ function formatValue(_key, value) {
 // This limit prevents performance issues when generating large numbers of component variations.
 // See: https://github.com/cloudscape-design/components/pull/3126
 const maximumPermutations = 276;
-export function PermutationsView({ permutations, render }) {
+export function PermutationsView({ permutations, render, direction = "vertical" }) {
     if (permutations.length > maximumPermutations) {
         throw new Error(`Too many permutations (${permutations.length}), maximum is ${maximumPermutations}`);
     }
-    return (React.createElement("div", { style: { display: "flex", flexDirection: "column", gap: "16px" } }, permutations.map((permutation, index) => {
+    const flexDirection = direction === "vertical" ? "column" : "row";
+    return (React.createElement("div", { style: { display: "flex", flexDirection: flexDirection, gap: "16px" } }, permutations.map((permutation, index) => {
         const id = JSON.stringify(permutation, formatValue);
         return (React.createElement("div", { key: id, "data-permutation": id }, render(permutation, index)));
     })));

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
+    "./lib/dev-pages-utils": {
+      "types": "./lib/dev-pages-utils/index.d.ts",
+      "default": "./lib/dev-pages-utils/index.js"
+    },
     "./lib/*": "./lib/*",
     "./*": "./lib/*"
   },

--- a/src/dev-pages-utils/__tests__/permutations-view.test.tsx
+++ b/src/dev-pages-utils/__tests__/permutations-view.test.tsx
@@ -85,4 +85,27 @@ describe("PermutationsView", () => {
 
     expect(result.props.children).toHaveLength(276);
   });
+
+  test("renders with horizontal direction", () => {
+    const permutations = [{ label: "First" }];
+
+    const result = PermutationsView({
+      permutations,
+      render: props => <div>{props.label}</div>,
+      direction: "horizontal",
+    });
+
+    expect(result.props.style.flexDirection).toBe("row");
+  });
+
+  test("defaults to vertical direction", () => {
+    const permutations = [{ label: "First" }];
+
+    const result = PermutationsView({
+      permutations,
+      render: props => <div>{props.label}</div>,
+    });
+
+    expect(result.props.style.flexDirection).toBe("column");
+  });
 });

--- a/src/dev-pages-utils/permutations-view.tsx
+++ b/src/dev-pages-utils/permutations-view.tsx
@@ -6,6 +6,7 @@ import React from "react";
 export interface PermutationsViewProps<T> {
   permutations: ReadonlyArray<T>;
   render: (_props: T, _index?: number) => React.ReactElement;
+  direction?: "vertical" | "horizontal";
 }
 
 function formatValue(_key: string, value: any) {
@@ -24,13 +25,13 @@ function formatValue(_key: string, value: any) {
 // See: https://github.com/cloudscape-design/components/pull/3126
 const maximumPermutations = 276;
 
-export function PermutationsView<T>({ permutations, render }: PermutationsViewProps<T>) {
+export function PermutationsView<T>({ permutations, render, direction = "vertical" }: PermutationsViewProps<T>) {
   if (permutations.length > maximumPermutations) {
     throw new Error(`Too many permutations (${permutations.length}), maximum is ${maximumPermutations}`);
   }
-
+  const flexDirection = direction === "vertical" ? "column" : "row";
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+    <div style={{ display: "flex", flexDirection: flexDirection, gap: "16px" }}>
       {permutations.map((permutation, index) => {
         const id = JSON.stringify(permutation, formatValue);
         return (


### PR DESCRIPTION
### Description
Adds explicit package export for ./lib/dev-pages-utils to support bundlers that require exact file resolution. Node.js wildcard exports (./lib/*) don't automatically resolve to index.js, causing build failures in Vite/Rollup.

It also adds a props to allow to change the direction of the view to horizontal, and vertical. this is useful to use the permutation view in the chart-components.

Tested:
- consuming the package locally and making sure it doesn't break anything used components package, and chat-component package.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
