### PR TITLE
chore: Switch to @tony.ganchev/eslint-plugin-header

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,9 +9,9 @@
       "jsx": true
     }
   },
-  "plugins": ["unicorn", "header", "@typescript-eslint"],
+  "plugins": ["unicorn", "@tony.ganchev/header", "@typescript-eslint"],
   "rules": {
-    "header/header": [
+    "@tony.ganchev/header/header": [
       "error",
       "line",
       [" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.", " SPDX-License-Identifier: Apache-2.0"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "prepare-package-lock": "lib/scripts/prepare-package-lock.js"
       },
       "devDependencies": {
+        "@tony.ganchev/eslint-plugin-header": "^3.3.1",
         "@types/lodash": "^4.17.21",
         "@types/node": "^20.19.24",
         "@types/react": "^16.14.0",
@@ -24,7 +25,6 @@
         "@vitest/coverage-v8": "^4.0.6",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
-        "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-no-unsanitized": "^4.0.2",
         "eslint-plugin-prettier": "^5.2.1",
@@ -1318,6 +1318,16 @@
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tony.ganchev/eslint-plugin-header": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@tony.ganchev/eslint-plugin-header/-/eslint-plugin-header-3.3.1.tgz",
+      "integrity": "sha512-/Fj0+DaXbBfrlXmd3wBZkB8TIwGT3N++y/oTYxRABK/gzNxjgcBjt63xBpuHCYIXmH1EwuALd6XS1fzNG4S0zg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=7.7.0"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3148,16 +3158,6 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-plugin-header": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
-      "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "eslint": ">=7.7.0"
       }
     },
     "node_modules/eslint-plugin-import": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "stylelint": "^16.8.1"
   },
   "devDependencies": {
+    "@tony.ganchev/eslint-plugin-header": "^3.3.1",
     "@types/lodash": "^4.17.21",
     "@types/node": "^20.19.24",
     "@types/react": "^16.14.0",
@@ -41,7 +42,6 @@
     "@vitest/coverage-v8": "^4.0.6",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-header": "^3.1.1",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-no-unsanitized": "^4.0.2",
     "eslint-plugin-prettier": "^5.2.1",


### PR DESCRIPTION
Hi, team,

I noticed you are using _eslint-plugin-header_ on ESLint 8.

I forked _@tony.ganchev/eslint-plugin-header_ mid-2024 to add support
for ESLint 9 and hoped it would be a temporary measure but since the
original has not been updated for five years I decided to continue
improving the new plugin and have been doing so for the last two years.

Specific improvements include:
- full JSON schema for validating the configuration.
- fixed multiple bugs with the behavior of the plugin on Windows.
- many other bug-fixes.
- improved autofixing and error-reporting behavior.
- added support for leading pragma comments before the header such as
  `@jest-environment`.

I've sent PR proposals to other projects in the _cloudscape-design_
space:
- https://github.com/cloudscape-design/board-components/pull/401
- https://github.com/cloudscape-design/browser-test-tools/pull/188
- https://github.com/cloudscape-design/chart-components/pull/185
- https://github.com/cloudscape-design/chat-components/pull/121
- https://github.com/cloudscape-design/code-view/pull/122
- https://github.com/cloudscape-design/collection-hooks/pull/136
- https://github.com/cloudscape-design/component-toolkit/pull/200
- https://github.com/cloudscape-design/components/pull/4308
- https://github.com/cloudscape-design/demos/pull/243
- https://github.com/cloudscape-design/documenter/pull/112
- https://github.com/cloudscape-design/global-styles/pull/73
- https://github.com/cloudscape-design/jest-preset/pull/58
- https://github.com/cloudscape-design/test-utils/pull/114
- https://github.com/cloudscape-design/theming-core/pull/148

Looking forward to your feedback.

### How has this been tested?

```
npm run lint
```

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
