### PR TITLE
chore: Adds ban files eslint rule

### DIFF
--- a/lib/eslint/__tests__/ban-files.test.js
+++ b/lib/eslint/__tests__/ban-files.test.js
@@ -1,0 +1,105 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, test } from "vitest";
+import { RuleTester } from "eslint";
+import banFiles from "../ban-files";
+
+const ruleHardcodedPath = [
+  {
+    pattern: "./src/index.ts",
+    message: `Disallowed import '{{ path }}' in favor of having smaller bundle sizes.`,
+  },
+];
+const ruleWildcardPath = [
+  {
+    pattern: "./src/*/index.tsx",
+    message: `Disallowed import '{{ path }}'.\nUse the internal component for composition instead.`,
+  },
+];
+const defaultRules = [...ruleHardcodedPath, ...ruleWildcardPath];
+
+const runRule = testCase =>
+  new RuleTester({ parserOptions: { ecmaVersion: 2015, sourceType: "module" } }).run("ban-files", banFiles, {
+    valid: [],
+    invalid: [],
+    ...testCase,
+  });
+
+describe("ban-files", () => {
+  test("all cases", () => runRule({
+  valid: [
+    {
+      code: 'import "../icon/internal.tsx"',
+      filename: "./src/button/index.tsx",
+      options: [defaultRules],
+    },
+    {
+      code: 'import "../index"',
+      filename: "./src/internal/components/chart-filter/index.ts",
+      options: [defaultRules],
+    },
+  ],
+
+  invalid: [
+    {
+      code: 'import "../"',
+      filename: "./src/button/index.tsx",
+      options: [ruleHardcodedPath],
+      errors: [{ message: "Disallowed import 'src/index.ts' in favor of having smaller bundle sizes." }],
+    },
+    {
+      code: 'import "../index"',
+      filename: "./src/button/index.tsx",
+      options: [ruleHardcodedPath],
+      errors: [{ message: "Disallowed import 'src/index.ts' in favor of having smaller bundle sizes." }],
+    },
+    {
+      code: 'import "../../"',
+      filename: "./src/select/parts/filter.tsx",
+      options: [ruleHardcodedPath],
+      errors: [{ message: "Disallowed import 'src/index.ts' in favor of having smaller bundle sizes." }],
+    },
+    {
+      code: 'import "../button"',
+      filename: "./src/alert/index.tsx",
+      options: [ruleWildcardPath],
+      errors: [
+        { message: "Disallowed import 'src/button/index.tsx'.\nUse the internal component for composition instead." },
+      ],
+    },
+    {
+      code: 'import "../../button"',
+      filename: "./src/internal/dropdown/index.tsx",
+      options: [ruleWildcardPath],
+      errors: [
+        { message: "Disallowed import 'src/button/index.tsx'.\nUse the internal component for composition instead." },
+      ],
+    },
+    {
+      code: 'import "../../button/index.tsx"',
+      filename: "./src/internal/dropdown/index.tsx",
+      options: [ruleWildcardPath],
+      errors: [
+        { message: "Disallowed import 'src/button/index.tsx'.\nUse the internal component for composition instead." },
+      ],
+    },
+    {
+      code: 'import "../icon"',
+      filename: "./src/button/index.tsx",
+      options: [ruleWildcardPath],
+      errors: [
+        { message: "Disallowed import 'src/icon/index.tsx'.\nUse the internal component for composition instead." },
+      ],
+    },
+    {
+      code: 'import "../../index"',
+      filename: "./src/internal/components/dummy-component/index.tsx",
+      options: [ruleWildcardPath],
+      errors: [
+        { message: "Disallowed import 'src/internal/index.tsx'.\nUse the internal component for composition instead." },
+      ],
+    },
+  ],
+  }));
+});

--- a/lib/eslint/ban-files.js
+++ b/lib/eslint/ban-files.js
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+const path = require('path');
+const micromatch = require('micromatch');
+
+const tryExtensions = ['.ts', '.tsx', '.js'];
+
+function checkPath(filePath, bannedFileConfig, node, context) {
+  for (const bannedFile of bannedFileConfig) {
+    const { pattern, message } = bannedFile;
+
+    if (micromatch.isMatch(filePath, pattern)) {
+      context.report({
+        node: node.source,
+        message: `${message}`,
+        data: {
+          path: path.relative(process.cwd(), filePath),
+        },
+      });
+    }
+  }
+}
+
+module.exports = {
+  meta: {
+    schema: [
+      {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            pattern: {
+              type: 'string',
+            },
+            message: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    ],
+  },
+  create(context) {
+    const bannedFileConfig = context.options[0].map(item => {
+      return {
+        ...item,
+        pattern: path.resolve(item.pattern),
+      };
+    });
+
+    const sourcePath = context.getFilename();
+    return {
+      ImportDeclaration(node) {
+        const importedPath = node.source.value;
+        if (importedPath.startsWith('.')) {
+          const resolvedPath = path.resolve(path.dirname(sourcePath), importedPath);
+          checkPath(resolvedPath, bannedFileConfig, node, context);
+          for (const ext of tryExtensions) {
+            checkPath(`${resolvedPath}${ext}`, bannedFileConfig, node, context);
+            checkPath(`${path.join(resolvedPath, 'index')}${ext}`, bannedFileConfig, node, context);
+          }
+        }
+      },
+    };
+  },
+};

--- a/lib/eslint/index.js
+++ b/lib/eslint/index.js
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import badFiles from "./ban-files.js";
+import banFiles from "./ban-files.js";
 import rscDirective from "./react-server-components-directive.js";
 
 export default {
   rules: {
-    "ban-files": badFiles,
+    "ban-files": banFiles,
     "react-server-components-directive": rscDirective,
   },
 };

--- a/lib/eslint/index.js
+++ b/lib/eslint/index.js
@@ -1,10 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import badFiles from "./ban-files.js";
 import rscDirective from "./react-server-components-directive.js";
 
 export default {
   rules: {
+    "ban-files": badFiles,
     "react-server-components-directive": rscDirective,
   },
 };


### PR DESCRIPTION
### Description

The ban-files is an existing rule in the components repo, but we now need to use it in all component repos to validate test-utils imports, see: https://github.com/cloudscape-design/components/pull/4423

Once this PR is merged - I will create a follow-up PR to remove the original ban-files rule from the components repo in favour of the shared one.

### How has this been tested?

* Existing ban-files unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
