### PR TITLE
feat: add reusable app mode url parser

### DIFF
--- a/lib/dev-pages-utils/__tests__/app-modes.test.ts
+++ b/lib/dev-pages-utils/__tests__/app-modes.test.ts
@@ -2,19 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, test, vi } from "vitest";
 
-// global-styles is a workspace sibling that is not installed in this package's node_modules.
-// app-modes.ts imports it at module load, so we stub it with the real enum string values.
-vi.mock("@cloudscape-design/global-styles", () => ({
-  Mode: { Light: "light", Dark: "dark" },
-  Density: { Comfortable: "comfortable", Compact: "compact" },
-  Theme: { Default: "default", VisualRefresh: "visual-refresh", OneTheme: "one-theme" },
-  applyMode: () => {},
-  applyDensity: () => {},
-  applyTheme: () => {},
-  disableMotion: () => {},
-}));
+import { Density, Mode } from "@cloudscape-design/global-styles";
 
-const { appModesDefaults, formatAppModes, updateAppModes } = await import("../app-modes");
+import { appModesDefaults, formatAppModes, updateAppModes } from "../app-modes";
 
 describe("formatAppModes", () => {
   test("serializes every param to a string (full URL, no omission)", () => {
@@ -30,14 +20,14 @@ describe("formatAppModes", () => {
   });
 
   test("skips undefined values", () => {
-    expect(formatAppModes({ mode: "dark", appLayoutToolbar: undefined })).toEqual({ mode: "dark" });
+    expect(formatAppModes({ mode: Mode.Dark, appLayoutToolbar: undefined })).toEqual({ mode: "dark" });
   });
 });
 
 describe("updateAppModes", () => {
   test("writes the full serialized query through setQuery", () => {
     const setQuery = vi.fn();
-    updateAppModes(appModesDefaults, { mode: "dark" as any }, setQuery);
+    updateAppModes(appModesDefaults, { mode: Mode.Dark }, setQuery);
     expect(setQuery).toHaveBeenCalledWith({
       mode: "dark",
       density: "comfortable",
@@ -52,7 +42,7 @@ describe("updateAppModes", () => {
   test("does not reload when direction is unchanged", () => {
     const reload = vi.fn();
     vi.stubGlobal("window", { location: { reload } });
-    updateAppModes(appModesDefaults, { mode: "dark" as any }, vi.fn());
+    updateAppModes(appModesDefaults, { mode: Mode.Dark }, vi.fn());
     expect(reload).not.toHaveBeenCalled();
     vi.unstubAllGlobals();
   });
@@ -68,7 +58,7 @@ describe("updateAppModes", () => {
   test("does not reload when next omits direction even if current is non-default", () => {
     const reload = vi.fn();
     vi.stubGlobal("window", { location: { reload } });
-    updateAppModes({ ...appModesDefaults, direction: "rtl" }, { mode: "dark" as any }, vi.fn());
+    updateAppModes({ ...appModesDefaults, direction: "rtl" }, { density: Density.Compact }, vi.fn());
     expect(reload).not.toHaveBeenCalled();
     vi.unstubAllGlobals();
   });

--- a/lib/dev-pages-utils/__tests__/app-modes.test.ts
+++ b/lib/dev-pages-utils/__tests__/app-modes.test.ts
@@ -13,7 +13,6 @@ describe("formatAppModes", () => {
       density: "comfortable",
       direction: "ltr",
       motionDisabled: "false",
-      theme: "default",
       i18n: "true",
       screenshotMode: "false",
     });
@@ -33,7 +32,6 @@ describe("updateAppModes", () => {
       density: "comfortable",
       direction: "ltr",
       motionDisabled: "false",
-      theme: "default",
       i18n: "true",
       screenshotMode: "false",
     });

--- a/lib/dev-pages-utils/__tests__/app-modes.test.ts
+++ b/lib/dev-pages-utils/__tests__/app-modes.test.ts
@@ -1,0 +1,75 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, test, vi } from "vitest";
+
+// global-styles is a workspace sibling that is not installed in this package's node_modules.
+// app-modes.ts imports it at module load, so we stub it with the real enum string values.
+vi.mock("@cloudscape-design/global-styles", () => ({
+  Mode: { Light: "light", Dark: "dark" },
+  Density: { Comfortable: "comfortable", Compact: "compact" },
+  Theme: { Default: "default", VisualRefresh: "visual-refresh", OneTheme: "one-theme" },
+  applyMode: () => {},
+  applyDensity: () => {},
+  applyTheme: () => {},
+  disableMotion: () => {},
+}));
+
+const { appModesDefaults, formatAppModes, updateAppModes } = await import("../app-modes");
+
+describe("formatAppModes", () => {
+  test("serializes every param to a string (full URL, no omission)", () => {
+    expect(formatAppModes(appModesDefaults)).toEqual({
+      mode: "light",
+      density: "comfortable",
+      direction: "ltr",
+      motionDisabled: "false",
+      theme: "default",
+      i18n: "true",
+      screenshotMode: "false",
+    });
+  });
+
+  test("skips undefined values", () => {
+    expect(formatAppModes({ mode: "dark", appLayoutToolbar: undefined })).toEqual({ mode: "dark" });
+  });
+});
+
+describe("updateAppModes", () => {
+  test("writes the full serialized query through setQuery", () => {
+    const setQuery = vi.fn();
+    updateAppModes(appModesDefaults, { mode: "dark" as any }, setQuery);
+    expect(setQuery).toHaveBeenCalledWith({
+      mode: "dark",
+      density: "comfortable",
+      direction: "ltr",
+      motionDisabled: "false",
+      theme: "default",
+      i18n: "true",
+      screenshotMode: "false",
+    });
+  });
+
+  test("does not reload when direction is unchanged", () => {
+    const reload = vi.fn();
+    vi.stubGlobal("window", { location: { reload } });
+    updateAppModes(appModesDefaults, { mode: "dark" as any }, vi.fn());
+    expect(reload).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  test("reloads when direction changes via next", () => {
+    const reload = vi.fn();
+    vi.stubGlobal("window", { location: { reload } });
+    updateAppModes(appModesDefaults, { direction: "rtl" }, vi.fn());
+    expect(reload).toHaveBeenCalledOnce();
+    vi.unstubAllGlobals();
+  });
+
+  test("does not reload when next omits direction even if current is non-default", () => {
+    const reload = vi.fn();
+    vi.stubGlobal("window", { location: { reload } });
+    updateAppModes({ ...appModesDefaults, direction: "rtl" }, { mode: "dark" as any }, vi.fn());
+    expect(reload).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+});

--- a/lib/dev-pages-utils/__tests__/app-modes.test.ts
+++ b/lib/dev-pages-utils/__tests__/app-modes.test.ts
@@ -4,7 +4,25 @@ import { describe, expect, test, vi } from "vitest";
 
 import { Density, Mode } from "@cloudscape-design/global-styles";
 
-import { appModesDefaults, formatAppModes, updateAppModes } from "../app-modes";
+import { appModesDefaults, formatAppModes, parseAppModes, updateAppModes } from "../app-modes";
+
+describe("parseAppModes", () => {
+  test("casts boolean strings and applies defaults for absent params", () => {
+    const params = parseAppModes(new URLSearchParams("mode=dark&motionDisabled=true"));
+    expect(params.mode).toBe("dark");
+    expect(params.motionDisabled).toBe(true);
+    expect(params.density).toBe("comfortable"); // default
+    expect(params.i18n).toBe(true); // default
+  });
+
+  test("keeps a valid theme", () => {
+    expect(parseAppModes(new URLSearchParams("theme=one-theme")).theme).toBe("one-theme");
+  });
+
+  test("leaves theme undefined when absent", () => {
+    expect(parseAppModes(new URLSearchParams("")).theme).toBeUndefined();
+  });
+});
 
 describe("formatAppModes", () => {
   test("serializes every param to a string (full URL, no omission)", () => {

--- a/lib/dev-pages-utils/app-modes-provider.tsx
+++ b/lib/dev-pages-utils/app-modes-provider.tsx
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { createContext, ReactNode, useCallback, useContext, useEffect, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+
+import { AppContextType, appModesDefaults, applyAppModes, AppUrlParams, parseAppModes, updateAppModes } from "./app-modes.js";
+
+const AppModesContext = createContext<AppContextType>({
+  urlParams: appModesDefaults,
+  setUrlParams: () => {},
+});
+
+export function AppModesProvider({ children }: { children: ReactNode }) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Depend on the whole object (memoized on the query) rather than enumerating params, so params
+  // added to parseAppModes/applyAppModes re-apply without touching this file or its consumers.
+  const urlParams = useMemo(() => parseAppModes(searchParams), [searchParams]);
+
+  const setUrlParams = useCallback(
+    (newParams: Partial<AppUrlParams>) => updateAppModes(urlParams, newParams, setSearchParams),
+    [urlParams, setSearchParams]
+  );
+
+  useEffect(() => {
+    applyAppModes(urlParams);
+  }, [urlParams]);
+
+  const value = useMemo<AppContextType>(() => ({ urlParams, setUrlParams }), [urlParams, setUrlParams]);
+
+  return <AppModesContext.Provider value={value}>{children}</AppModesContext.Provider>;
+}
+
+// Pass a type argument for package-specific params, e.g. useAppModes<{ myFlag: boolean }>().
+export function useAppModes<T = unknown>(): AppContextType<T> {
+  return useContext(AppModesContext) as AppContextType<T>;
+}

--- a/lib/dev-pages-utils/app-modes.ts
+++ b/lib/dev-pages-utils/app-modes.ts
@@ -10,6 +10,7 @@ import {
   Mode,
   Theme,
 } from "@cloudscape-design/global-styles";
+import mapValues from "lodash/mapValues";
 
 export interface AppUrlParams {
   mode: Mode;
@@ -44,16 +45,18 @@ export const appModesDefaults: AppUrlParams = {
  */
 export function parseAppModes(searchParams: URLSearchParams): AppUrlParams {
   const queryParams: Record<string, any> = { ...appModesDefaults };
-  searchParams.forEach((value, key) => {
-    queryParams[key] = value === "true" || value === "false" ? value === "true" : value;
-  });
+  searchParams.forEach((value, key) => (queryParams[key] = value));
 
   const themeValues = Object.values(Theme) as string[];
-  if (!themeValues.includes(queryParams.theme)) {
-    queryParams.theme = Theme.Default;
-  }
-
-  return queryParams as AppUrlParams;
+  return mapValues(queryParams, (value, key) => {
+    if (key === "theme") {
+      return themeValues.includes(value) ? value : Theme.Default;
+    }
+    if (value === "true" || value === "false") {
+      return value === "true";
+    }
+    return value;
+  }) as AppUrlParams;
 }
 
 /** 

--- a/lib/dev-pages-utils/app-modes.ts
+++ b/lib/dev-pages-utils/app-modes.ts
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  applyDensity,
+  applyMode,
+  applyTheme,
+  disableMotion,
+  Density,
+  Mode,
+  Theme,
+} from "@cloudscape-design/global-styles";
+
+export interface AppUrlParams {
+  mode: Mode;
+  density: Density;
+  direction: "ltr" | "rtl";
+  motionDisabled: boolean;
+  theme: Theme;
+  i18n?: boolean;
+  screenshotMode?: boolean;
+}
+
+/**
+ * Shared shape for a dev-pages app context. Extend the params with package-specific fields via
+ * the generic `T` (e.g. useAppContext<{ visualRefresh: boolean }>()).
+ */
+export interface AppContextType<T = unknown> {
+  pageId?: string;
+  urlParams: AppUrlParams & T;
+  setUrlParams: (newParams: Partial<AppUrlParams & T>) => void;
+}
+
+export const appModesDefaults: AppUrlParams = {
+  mode: Mode.Light,
+  density: Density.Comfortable,
+  direction: "ltr",
+  motionDisabled: false,
+  theme: Theme.Default,
+  i18n: true,
+  screenshotMode: false,
+};
+
+/**
+ * Parses dev-pages URL params into a typed object. Every known param lives on AppUrlParams;
+ * params absent from the URL fall back to appModesDefaults. String values of "true"/"false" are
+ * cast to booleans, and an unrecognized `theme` falls back to Theme.Default.
+ */
+export function parseAppModes(searchParams: URLSearchParams): AppUrlParams {
+  const queryParams: Record<string, any> = { ...appModesDefaults };
+  searchParams.forEach((value, key) => {
+    queryParams[key] = value === "true" || value === "false" ? value === "true" : value;
+  });
+
+  const themeValues = Object.values(Theme) as string[];
+  if (!themeValues.includes(queryParams.theme)) {
+    queryParams.theme = Theme.Default;
+  }
+
+  return queryParams as AppUrlParams;
+}
+
+/** Serializes params to a query record. Emits every param (skipping only `undefined` values). */
+export function formatAppModes<T extends object>(params: T): Record<string, string> {
+  const query: Record<string, string> = {};
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) {
+      continue;
+    }
+    query[key] = String(value);
+  }
+  return query;
+}
+
+/**
+ * Router-agnostic setter for app-modes URL state: serializes `current` merged with `next`, writes
+ * it through the caller-provided `setQuery` (e.g. react-router's `setSearchParams`), and reloads
+ * the page when `direction` changed.
+ */
+export function updateAppModes(
+  current: AppUrlParams,
+  next: Partial<AppUrlParams>,
+  setQuery: (query: Record<string, string>) => void,
+): void {
+  const merged = { ...current, ...next };
+  setQuery(formatAppModes(merged));
+  if ((next.direction ?? current.direction) !== current.direction) {
+    window.location.reload();
+  }
+}
+
+export function applyAppModes(params: AppUrlParams, target: Element = document.body): void {
+  applyMode(params.mode, target);
+  applyDensity(params.density, target);
+  disableMotion(params.motionDisabled, target);
+  applyTheme(params.theme, target);
+  document.documentElement.setAttribute("dir", params.direction);
+}

--- a/lib/dev-pages-utils/app-modes.ts
+++ b/lib/dev-pages-utils/app-modes.ts
@@ -22,8 +22,7 @@ export interface AppUrlParams {
 }
 
 /**
- * Shared shape for a dev-pages app context. Extend the params with package-specific fields via
- * the generic `T` (e.g. useAppContext<{ visualRefresh: boolean }>()).
+ * Shared shape for a dev-pages app context.
  */
 export interface AppContextType<T = unknown> {
   pageId?: string;
@@ -42,9 +41,7 @@ export const appModesDefaults: AppUrlParams = {
 };
 
 /**
- * Parses dev-pages URL params into a typed object. Every known param lives on AppUrlParams;
- * params absent from the URL fall back to appModesDefaults. String values of "true"/"false" are
- * cast to booleans, and an unrecognized `theme` falls back to Theme.Default.
+ * Parses dev-pages URL params into a typed object.
  */
 export function parseAppModes(searchParams: URLSearchParams): AppUrlParams {
   const queryParams: Record<string, any> = { ...appModesDefaults };
@@ -60,13 +57,13 @@ export function parseAppModes(searchParams: URLSearchParams): AppUrlParams {
   return queryParams as AppUrlParams;
 }
 
-/** Serializes params to a query record. Emits every param (skipping only `undefined` values). */
+/** 
+ * Serializes params to a query record. Skips undefined values.
+ */
 export function formatAppModes<T extends object>(params: T): Record<string, string> {
   const query: Record<string, string> = {};
   for (const [key, value] of Object.entries(params)) {
-    if (value === undefined) {
-      continue;
-    }
+    if (value === undefined) continue;
     query[key] = String(value);
   }
   return query;

--- a/lib/dev-pages-utils/app-modes.ts
+++ b/lib/dev-pages-utils/app-modes.ts
@@ -16,7 +16,7 @@ export interface AppUrlParams {
   density: Density;
   direction: "ltr" | "rtl";
   motionDisabled: boolean;
-  theme: Theme;
+  theme?: Theme;
   i18n?: boolean;
   screenshotMode?: boolean;
 }
@@ -35,7 +35,6 @@ export const appModesDefaults: AppUrlParams = {
   density: Density.Comfortable,
   direction: "ltr",
   motionDisabled: false,
-  theme: Theme.Default,
   i18n: true,
   screenshotMode: false,
 };
@@ -90,6 +89,6 @@ export function applyAppModes(params: AppUrlParams, target: Element = document.b
   applyMode(params.mode, target);
   applyDensity(params.density, target);
   disableMotion(params.motionDisabled, target);
-  applyTheme(params.theme, target);
+  applyTheme(params.theme ?? null, target);
   document.documentElement.setAttribute("dir", params.direction);
 }

--- a/lib/dev-pages-utils/app-modes.ts
+++ b/lib/dev-pages-utils/app-modes.ts
@@ -47,11 +47,7 @@ export function parseAppModes(searchParams: URLSearchParams): AppUrlParams {
   const queryParams: Record<string, any> = { ...appModesDefaults };
   searchParams.forEach((value, key) => (queryParams[key] = value));
 
-  const themeValues = Object.values(Theme) as string[];
-  return mapValues(queryParams, (value, key) => {
-    if (key === "theme") {
-      return themeValues.includes(value) ? value : Theme.Default;
-    }
+  return mapValues(queryParams, value => {
     if (value === "true" || value === "false") {
       return value === "true";
     }
@@ -59,7 +55,7 @@ export function parseAppModes(searchParams: URLSearchParams): AppUrlParams {
   }) as AppUrlParams;
 }
 
-/** 
+/**
  * Serializes params to a query record. Skips undefined values.
  */
 export function formatAppModes<T extends object>(params: T): Record<string, string> {

--- a/lib/dev-pages-utils/app-modes.ts
+++ b/lib/dev-pages-utils/app-modes.ts
@@ -22,9 +22,6 @@ export interface AppUrlParams {
   screenshotMode?: boolean;
 }
 
-/**
- * Shared shape for a dev-pages app context.
- */
 export interface AppContextType<T = unknown> {
   pageId?: string;
   urlParams: AppUrlParams & T;
@@ -40,9 +37,6 @@ export const appModesDefaults: AppUrlParams = {
   screenshotMode: false,
 };
 
-/**
- * Parses dev-pages URL params into a typed object.
- */
 export function parseAppModes(searchParams: URLSearchParams): AppUrlParams {
   const queryParams: Record<string, any> = { ...appModesDefaults };
   searchParams.forEach((value, key) => (queryParams[key] = value));
@@ -55,9 +49,6 @@ export function parseAppModes(searchParams: URLSearchParams): AppUrlParams {
   }) as AppUrlParams;
 }
 
-/**
- * Serializes params to a query record. Skips undefined values.
- */
 export function formatAppModes<T extends object>(params: T): Record<string, string> {
   const query: Record<string, string> = {};
   for (const [key, value] of Object.entries(params)) {
@@ -67,11 +58,7 @@ export function formatAppModes<T extends object>(params: T): Record<string, stri
   return query;
 }
 
-/**
- * Router-agnostic setter for app-modes URL state: serializes `current` merged with `next`, writes
- * it through the caller-provided `setQuery` (e.g. react-router's `setSearchParams`), and reloads
- * the page when `direction` changed.
- */
+// Reloads on direction change: some components read the document `dir` only at mount.
 export function updateAppModes(
   current: AppUrlParams,
   next: Partial<AppUrlParams>,

--- a/lib/dev-pages-utils/index.ts
+++ b/lib/dev-pages-utils/index.ts
@@ -4,13 +4,6 @@
 import { PermutationsView, PermutationsViewProps } from "./permutations-view.js";
 import { createPermutations, ComponentPermutations } from "./permutations.js";
 
-export {
-  type AppUrlParams,
-  type AppContextType,
-  appModesDefaults,
-  applyAppModes,
-  formatAppModes,
-  parseAppModes,
-  updateAppModes,
-} from "./app-modes.js";
+export { type AppUrlParams } from "./app-modes.js";
+export { AppModesProvider, useAppModes } from "./app-modes-provider.js";
 export { createPermutations, PermutationsView, type ComponentPermutations, type PermutationsViewProps };

--- a/lib/dev-pages-utils/index.ts
+++ b/lib/dev-pages-utils/index.ts
@@ -4,4 +4,13 @@
 import { PermutationsView, PermutationsViewProps } from "./permutations-view.js";
 import { createPermutations, ComponentPermutations } from "./permutations.js";
 
+export {
+  type AppUrlParams,
+  type AppContextType,
+  appModesDefaults,
+  applyAppModes,
+  formatAppModes,
+  parseAppModes,
+  updateAppModes,
+} from "./app-modes.js";
 export { createPermutations, PermutationsView, type ComponentPermutations, type PermutationsViewProps };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@cloudscape-design/global-styles": "^1.0.62",
         "lodash": "^4.18.1",
         "minimatch": "^10.2.4"
       },
@@ -191,6 +192,12 @@
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
+    },
+    "node_modules/@cloudscape-design/global-styles": {
+      "version": "1.0.62",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/global-styles/-/global-styles-1.0.62.tgz",
+      "integrity": "sha512-8ll8m/Z2/nwHNBhGtEj/pqkBb08OkboyXoKef+D73HmUFgAOhhXCKUaqtF2SVOsvjHm5IffEQRvKK3/CQUeR1g==",
+      "license": "Apache-2.0"
     },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "3.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -193,12 +193,6 @@
         "@keyv/serialize": "^1.1.1"
       }
     },
-    "node_modules/@cloudscape-design/global-styles": {
-      "version": "1.0.62",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/global-styles/-/global-styles-1.0.62.tgz",
-      "integrity": "sha512-8ll8m/Z2/nwHNBhGtEj/pqkBb08OkboyXoKef+D73HmUFgAOhhXCKUaqtF2SVOsvjHm5IffEQRvKK3/CQUeR1g==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4414,9 +4414,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,10 +38,14 @@
         "lodash": "^4.18.1",
         "prettier": "^3.3.3",
         "react": "16.14.0",
+        "react-dom": "16.14.0",
+        "react-router-dom": "^6.30.4",
         "typescript": "^5.0.0",
         "vitest": "^4.1.8"
       },
       "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-router-dom": ">=6.0.0",
         "stylelint": "^16.8.1"
       }
     },
@@ -575,6 +579,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -5885,12 +5899,62 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-dom": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-router": {
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
     },
     "node_modules/read-pkg": {
       "version": "5.2.0",
@@ -6295,6 +6359,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "minimatch": "^10.2.4"
   },
   "peerDependencies": {
+    "react": ">=16.14.0",
+    "react-router-dom": ">=6.0.0",
     "stylelint": "^16.8.1"
   },
   "devDependencies": {
@@ -55,6 +57,8 @@
     "lodash": "^4.18.1",
     "prettier": "^3.3.3",
     "react": "16.14.0",
+    "react-dom": "16.14.0",
+    "react-router-dom": "^6.30.4",
     "typescript": "^5.0.0",
     "vitest": "^4.1.8"
   },

--- a/package.json
+++ b/package.json
@@ -35,12 +35,6 @@
     "react-router-dom": ">=6.0.0",
     "stylelint": "^16.8.1"
   },
-  "peerDependenciesMeta": {
-    "@cloudscape-design/global-styles": { "optional": true },
-    "react": { "optional": true },
-    "react-router-dom": { "optional": true },
-    "stylelint": { "optional": true }
-  },
   "devDependencies": {
     "@cloudscape-design/global-styles": "^1.0.62",
     "@tony.ganchev/eslint-plugin-header": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -26,16 +26,23 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@cloudscape-design/global-styles": "^1.0.62",
     "lodash": "^4.18.1",
     "minimatch": "^10.2.4"
   },
   "peerDependencies": {
+    "@cloudscape-design/global-styles": "^1.0.62",
     "react": ">=16.14.0",
     "react-router-dom": ">=6.0.0",
     "stylelint": "^16.8.1"
   },
+  "peerDependenciesMeta": {
+    "@cloudscape-design/global-styles": { "optional": true },
+    "react": { "optional": true },
+    "react-router-dom": { "optional": true },
+    "stylelint": { "optional": true }
+  },
   "devDependencies": {
+    "@cloudscape-design/global-styles": "^1.0.62",
     "@tony.ganchev/eslint-plugin-header": "^3.3.1",
     "@types/lodash": "^4.17.21",
     "@types/node": "^20.19.24",

--- a/package.json
+++ b/package.json
@@ -26,15 +26,14 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@cloudscape-design/global-styles": "^1.0.62",
     "lodash": "^4.18.1",
     "minimatch": "^10.2.4"
   },
   "peerDependencies": {
-    "@cloudscape-design/global-styles": "^1.0.62",
     "stylelint": "^16.8.1"
   },
   "devDependencies": {
-    "@cloudscape-design/global-styles": "^1.0.62",
     "@tony.ganchev/eslint-plugin-header": "^3.3.1",
     "@types/lodash": "^4.17.21",
     "@types/node": "^20.19.24",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,9 @@
     ],
     "*.{scss,css}": [
       "stylelint --fix"
+    ],
+    "package-lock.json": [
+      "node ./lib/scripts/prepare-package-lock.js"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,14 +26,15 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@cloudscape-design/global-styles": "^1.0.62",
     "lodash": "^4.18.1",
     "minimatch": "^10.2.4"
   },
   "peerDependencies": {
+    "@cloudscape-design/global-styles": "^1.0.62",
     "stylelint": "^16.8.1"
   },
   "devDependencies": {
+    "@cloudscape-design/global-styles": "^1.0.62",
     "@tony.ganchev/eslint-plugin-header": "^3.3.1",
     "@types/lodash": "^4.17.21",
     "@types/node": "^20.19.24",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@cloudscape-design/global-styles": "^1.0.62",
     "lodash": "^4.18.1",
     "minimatch": "^10.2.4"
   },


### PR DESCRIPTION
### Description

Introduces reusable app mode url parser and setter for dev pages which will replace the duplicate variants in sibling component packages.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
