### PR TITLE
fix: cap react-router-dom peer to v6 to keep React 16 downstreams resolvable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
       },
       "peerDependencies": {
         "react": ">=16.14.0",
-        "react-router-dom": ">=6.0.0",
+        "react-router-dom": "^6.0.0",
         "stylelint": "^16.8.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@cloudscape-design/global-styles": "^1.0.62",
     "react": ">=16.14.0",
-    "react-router-dom": ">=6.0.0",
+    "react-router-dom": "^6.0.0",
     "stylelint": "^16.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
Caps the `react-router-dom` peer dependency from `>=6.0.0` to `^6.0.0`.

The open-ended `>=6.0.0` range (added in #55) lets npm greedily resolve `react-router-dom@7` in downstream repos, and v7 peers `react@>=18`. Repos that dev-pin `react@^16.14.0` and track `build-tools#main` then fail `npm install` with ERESOLVE (e.g. collection-hooks#155 merge queue, components PRs). v7 is the major that drops React 16 support, so it must be excluded. All current consumers use v6 (`^6.30.4`) or lower, so the cap breaks none of them.

## How has this been tested?
Verified via the downstream survey that no consumer uses react-router-dom v7+. Real validation: re-queue collection-hooks#155 after this merges.
