### PR TITLE
fix: downgrade the react-router-dom to 5.3.2 atleast

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,14 @@
     "react-router-dom": ">=6.0.0",
     "stylelint": "^16.8.1"
   },
+  "peerDependenciesMeta": {                                                   
+    "react": {                                                                
+      "optional": true                                                        
+    },                                                                        
+    "react-router-dom": {                                                     
+      "optional": true                                                        
+    }                                                                         
+  },
   "devDependencies": {
     "@cloudscape-design/global-styles": "^1.0.62",
     "@tony.ganchev/eslint-plugin-header": "^3.3.1",


### PR DESCRIPTION
### Description
This is needed because we have conflict in the components repository when npm installing see [error](https://github.com/cloudscape-design/components/actions/runs/28852072714/job/85569607418?pr=4700). The react-router-dom was introduced as a peer dependency in https://github.com/cloudscape-design/build-tools/pull/55. Since we don't use the dev-page-utils in the components repository I have made the two new peer dependencies as optional.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?
Running unit tests, and by changing the package.json for the components to install from this.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
