### PR TITLE
chore: Adds public interfaces eslint rule

### DIFF
--- a/lib/eslint/__tests__/no-internal-in-public-interfaces.test.js
+++ b/lib/eslint/__tests__/no-internal-in-public-interfaces.test.js
@@ -1,0 +1,132 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { createRequire } from "node:module";
+
+import { RuleTester } from "eslint";
+import { describe, test } from "vitest";
+
+import rule from "../no-internal-in-public-interfaces";
+
+const require = createRequire(import.meta.url);
+
+// A public component interface file (the contract applies here).
+const PUBLIC = "./src/foo/interfaces.ts";
+const PUBLIC_TSX = "./src/foo/interfaces.tsx";
+// Locations where internal types legitimately live (the rule must be a no-op).
+const INTERNAL_INTERFACES = "./src/foo/internal-interfaces.ts";
+const INTERNAL_DIR_INDEX = "./src/internal/interfaces.ts";
+const NESTED_INTERFACES = "./src/internal/components/foo/interfaces.ts";
+const NON_INTERFACE = "./src/foo/internal.tsx";
+
+const runRule = testCase =>
+  new RuleTester({
+    parser: require.resolve("@typescript-eslint/parser"),
+    parserOptions: { ecmaVersion: 2020, sourceType: "module", ecmaFeatures: { jsx: true } },
+  }).run("no-internal-in-public-interfaces", rule, { valid: [], invalid: [], ...testCase });
+
+describe("no-internal-in-public-interfaces", () => {
+  test("valid", () =>
+    runRule({
+      valid: [
+        // Public types declared in a public interface file are fine.
+        { code: "export interface FooProps { id: string; }", filename: PUBLIC },
+        { code: 'export type Variant = "a" | "b";', filename: PUBLIC_TSX },
+        // Allowed sources: another component's interfaces, src/types, and external packages.
+        { code: "import { BarProps } from '../bar/interfaces';\nexport interface FooProps extends BarProps {}", filename: PUBLIC },
+        { code: "import { BaseComponentProps } from '../types/base-component';\nexport interface FooProps extends BaseComponentProps {}", filename: PUBLIC },
+        { code: "import React from 'react';\nexport interface FooProps { node: React.ReactNode; }", filename: PUBLIC },
+        { code: "import { PortalProps } from '@cloudscape-design/component-toolkit/internal';\nexport interface FooProps { p: PortalProps; }", filename: PUBLIC },
+        { code: "export { BarProps } from '../bar/interfaces';", filename: PUBLIC },
+        { code: "export type { Breakpoint } from '../types/breakpoint';", filename: PUBLIC },
+        // Aliasing a public imported type to a local Internal* name is fine (the declared name is public).
+        {
+          code: "import { Breakpoint as InternalBreakpoint } from '../types/breakpoint';\nexport type Breakpoint = InternalBreakpoint;",
+          filename: PUBLIC,
+        },
+        // The rule is a no-op outside public interface files.
+        {
+          code: "import { InternalBaseComponentProps } from '../internal/base-component';\nimport { ItemProps } from './internal-interfaces';\nexport interface InternalFooProps extends InternalBaseComponentProps {}",
+          filename: INTERNAL_INTERFACES,
+        },
+        { code: "import { x } from './helper';\nexport interface InternalThing { x: typeof x; }", filename: INTERNAL_DIR_INDEX },
+        { code: "import { x } from './helper';\nexport interface InternalNested { x: typeof x; }", filename: NESTED_INTERFACES },
+        { code: "import { x } from './ace-modes';\nexport type Y = typeof x;", filename: NON_INTERFACE },
+        // Respects a custom publicInterfacesPattern: a file not matching the pattern is ignored.
+        {
+          code: "import { InternalThing } from '../internal/types';\nexport type X = InternalThing;",
+          filename: PUBLIC,
+          options: [{ publicInterfacesPattern: "./widgets/*/interfaces.{ts,tsx}" }],
+        },
+      ],
+    }));
+
+  test("invalid", () =>
+    runRule({
+      invalid: [
+        // Declaring an internal-named type in a public interface file.
+        {
+          code: "export interface InternalFooProps { id: string; }",
+          filename: PUBLIC,
+          errors: [{ messageId: "internalDeclaration", data: { name: "InternalFooProps" } }],
+        },
+        {
+          code: "interface InternalHelper { x: number; }\nexport interface FooProps { h: InternalHelper; }",
+          filename: PUBLIC,
+          errors: [{ messageId: "internalDeclaration", data: { name: "InternalHelper" } }],
+        },
+        // Importing from a sibling internal-interfaces module.
+        {
+          code: "import { ItemProps } from './internal-interfaces';\nexport interface FooProps { item: ItemProps; }",
+          filename: PUBLIC,
+          errors: [{ messageId: "disallowedImport", data: { source: "./internal-interfaces" } }],
+        },
+        {
+          code: "import { InternalToken } from '../property-filter/internal-interfaces';\nexport type X = InternalToken;",
+          filename: PUBLIC,
+          errors: [{ messageId: "disallowedImport", data: { source: "../property-filter/internal-interfaces" } }],
+        },
+        // Importing from src/internal.
+        {
+          code: "import { SomeRequired } from '../internal/types';\nexport type X = SomeRequired;",
+          filename: PUBLIC,
+          errors: [{ messageId: "disallowedImport", data: { source: "../internal/types" } }],
+        },
+        // Importing a type from a non-interface implementation file in another component.
+        {
+          code: "import { BaseCheckboxProps } from '../checkbox/base-checkbox';\nexport interface FooProps extends BaseCheckboxProps {}",
+          filename: PUBLIC,
+          errors: [{ messageId: "disallowedImport", data: { source: "../checkbox/base-checkbox" } }],
+        },
+        // Importing a type from a non-interface file in the same component.
+        {
+          code: "import { AceModes } from './ace-modes';\nexport type X = typeof AceModes;",
+          filename: PUBLIC,
+          errors: [{ messageId: "disallowedImport", data: { source: "./ace-modes" } }],
+        },
+        // Re-exporting from a disallowed source.
+        {
+          code: "export { InternalToken } from './internal-interfaces';",
+          filename: PUBLIC,
+          errors: [{ messageId: "disallowedReexport", data: { source: "./internal-interfaces" } }],
+        },
+        {
+          code: "export * from '../internal/types';",
+          filename: PUBLIC,
+          errors: [{ messageId: "disallowedReexport", data: { source: "../internal/types" } }],
+        },
+        // Re-exporting a binding under an internal name.
+        {
+          code: "import { Foo } from '../bar/interfaces';\nexport { Foo as InternalFoo };",
+          filename: PUBLIC,
+          errors: [{ messageId: "internalReexportName", data: { name: "InternalFoo" } }],
+        },
+        // A custom publicInterfacesPattern makes an otherwise-ignored path a public interface.
+        {
+          code: "import { InternalThing } from '../internal/types';\nexport type X = InternalThing;",
+          filename: "./widgets/foo/interfaces.ts",
+          options: [{ publicInterfacesPattern: "./widgets/*/interfaces.{ts,tsx}" }],
+          errors: [{ messageId: "disallowedImport", data: { source: "../internal/types" } }],
+        },
+      ],
+    }));
+});

--- a/lib/eslint/index.js
+++ b/lib/eslint/index.js
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import banFiles from "./ban-files.js";
+import noInternalInPublicInterfaces from "./no-internal-in-public-interfaces.js";
 import rscDirective from "./react-server-components-directive.js";
 
 export default {
   rules: {
     "ban-files": banFiles,
+    "no-internal-in-public-interfaces": noInternalInPublicInterfaces,
     "react-server-components-directive": rscDirective,
   },
 };

--- a/lib/eslint/no-internal-in-public-interfaces.js
+++ b/lib/eslint/no-internal-in-public-interfaces.js
@@ -1,0 +1,154 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import micromatch from "micromatch";
+import path from "node:path";
+
+/**
+ * Secures the public interfaces contract shared across Cloudscape component repositories
+ * (components, chat-components, board-components, code-view, chart-components).
+ *
+ * Public component interface files (by convention `src/{component}/interfaces.{ts,tsx}`) must
+ * expose ONLY public API types, so downstream design systems can safely proxy/extend them. Any
+ * intra-repo type can otherwise leak into a public interface by mistake (internal helpers,
+ * implementation files, `src/internal/**`, a sibling `internal-interfaces.ts`, etc.), so this rule
+ * uses an allowlist rather than a denylist.
+ *
+ * Within a public interface file, an import / re-export source is allowed only when it is:
+ *   - an external package (a non-relative specifier, e.g. `react`, `@cloudscape-design/*`); or
+ *   - another component's public interface file (a relative path ending in `/interfaces`); or
+ *   - the shared public types location (`src/types`, a relative path with a `types/` segment).
+ *
+ * It also forbids declaring or re-exporting `Internal*` named types in the public file. The rule is
+ * a no-op outside public interface files, so internal files (internal-interfaces.ts, src/internal,
+ * nested sub-module interfaces) are unaffected.
+ *
+ * The set of files treated as public interfaces is configurable via the `publicInterfacesPattern`
+ * option (a glob resolved against the project root); it defaults to the shared Cloudscape
+ * convention, so the rule works out of the box in every component repo.
+ */
+
+const DEFAULT_PUBLIC_INTERFACES_PATTERN = "./src/*/interfaces.{ts,tsx}";
+
+// Names starting with `Internal` followed by an upper-case letter are, by convention, internal types.
+const INTERNAL_NAME_RE = /^Internal[A-Z]/;
+
+// Extracts the component segment from a `.../src/{component}/interfaces.ts(x)` path.
+const COMPONENT_RE = /(?:^|\/)src\/([^/]+)\/interfaces\.tsx?$/;
+
+// Directory buckets under `src/` that are never public component interfaces.
+const NON_COMPONENT_SEGMENTS = new Set(["internal", "types"]);
+
+/**
+ * Whether a module specifier is an allowed import source for a public interface file.
+ */
+function isAllowedSource(source) {
+  if (typeof source !== "string") {
+    return true;
+  }
+  // External packages (anything that is not a relative path). The contract targets intra-repo types.
+  if (!source.startsWith(".")) {
+    return true;
+  }
+  // Another component's public interface file, e.g. `../button/interfaces`.
+  // Note: `internal-interfaces` ends in `-interfaces`, not `/interfaces`, so it is NOT allowed.
+  if (/\/interfaces$/.test(source)) {
+    return true;
+  }
+  // The shared public types location, e.g. `../types/base-component`.
+  if (/(?:^|\/)types\//.test(source)) {
+    return true;
+  }
+  return false;
+}
+
+export default {
+  meta: {
+    type: "problem",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          publicInterfacesPattern: {
+            type: "string",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      internalDeclaration:
+        "'{{name}}' looks like an internal type and must not be declared in a public interface file. Move it to a colocated 'internal-interfaces.ts' file.",
+      disallowedImport:
+        "Public interface files may only import from another component's interfaces (e.g. '../button/interfaces') or shared public types ('src/types'). Importing from '{{source}}' is not allowed — if it is a public type, move it to 'src/types' and import it from there.",
+      disallowedReexport:
+        "Public interface files may only re-export from another component's interfaces or shared public types ('src/types'). Re-exporting from '{{source}}' is not allowed, as it can expose internal types through the public API surface.",
+      internalReexportName: "Public interface files must not export '{{name}}' under an internal name.",
+    },
+    docs: {
+      description:
+        "Restricts imports in public component interface files to other component interfaces or shared public types (src/types), preventing internal types from leaking into the public API surface.",
+    },
+  },
+  create(context) {
+    const pattern = path.resolve(context.options[0]?.publicInterfacesPattern ?? DEFAULT_PUBLIC_INTERFACES_PATTERN);
+    const filename = path.resolve(context.filename ?? context.getFilename());
+    const normalized = filename.replace(/\\/g, "/");
+
+    if (!micromatch.isMatch(filename, pattern)) {
+      return {};
+    }
+    // Skip the internal/types buckets, which are not public component interfaces.
+    const componentMatch = COMPONENT_RE.exec(normalized);
+    if (componentMatch && NON_COMPONENT_SEGMENTS.has(componentMatch[1])) {
+      return {};
+    }
+
+    function reportInternalName(node, name) {
+      if (name && INTERNAL_NAME_RE.test(name)) {
+        context.report({ node, messageId: "internalDeclaration", data: { name } });
+      }
+    }
+
+    return {
+      // Declaring an internal-named type (exported or not) in the public file.
+      TSInterfaceDeclaration(node) {
+        reportInternalName(node.id, node.id && node.id.name);
+      },
+      TSTypeAliasDeclaration(node) {
+        reportInternalName(node.id, node.id && node.id.name);
+      },
+      TSEnumDeclaration(node) {
+        reportInternalName(node.id, node.id && node.id.name);
+      },
+
+      // Imports must come from an allowed source.
+      ImportDeclaration(node) {
+        const source = node.source && node.source.value;
+        if (!isAllowedSource(source)) {
+          context.report({ node, messageId: "disallowedImport", data: { source } });
+        }
+      },
+
+      // Re-exports must come from an allowed source; bindings must not be exposed under an internal name.
+      ExportNamedDeclaration(node) {
+        const source = node.source && node.source.value;
+        if (!isAllowedSource(source)) {
+          context.report({ node, messageId: "disallowedReexport", data: { source } });
+          return;
+        }
+        for (const spec of node.specifiers || []) {
+          const exportedName = spec.exported && spec.exported.name;
+          if (exportedName && INTERNAL_NAME_RE.test(exportedName)) {
+            context.report({ node: spec, messageId: "internalReexportName", data: { name: exportedName } });
+          }
+        }
+      },
+      ExportAllDeclaration(node) {
+        const source = node.source && node.source.value;
+        if (!isAllowedSource(source)) {
+          context.report({ node, messageId: "disallowedReexport", data: { source } });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
### Description

Moves linter util introduced here https://github.com/cloudscape-design/components/pull/4669 to the shared tools.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
