### PR TITLE
test: DO NOT MERGE — validate dry-run git-ref repin (actions#124)

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   dry-run:
-    uses: cloudscape-design/actions/.github/workflows/dry-run.yml@main
+    uses: cloudscape-design/actions/.github/workflows/dry-run.yml@dev-gethinw-dryrun-git-ref-pin-selftest

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "minimatch": "^10.2.4"
   },
   "peerDependencies": {
+    "react-dom": ">=18.0.0",
     "stylelint": "^16.8.1"
   },
   "peerDependenciesMeta": {                                                   

--- a/package.json
+++ b/package.json
@@ -30,16 +30,13 @@
     "minimatch": "^10.2.4"
   },
   "peerDependencies": {
-    "react-dom": ">=18.0.0",
+    "react-router-dom": ">=6.0.0",
     "stylelint": "^16.8.1"
   },
-  "peerDependenciesMeta": {                                                   
-    "react": {                                                                
-      "optional": true                                                        
-    },                                                                        
-    "react-router-dom": {                                                     
-      "optional": true                                                        
-    }                                                                         
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@tony.ganchev/eslint-plugin-header": "^3.3.1",
@@ -64,7 +61,8 @@
     "prettier": "^3.3.3",
     "react": "16.14.0",
     "typescript": "^5.0.0",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.8",
+    "react-router-dom": "^6.30.4"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "react": "16.14.0",
     "typescript": "^5.0.0",
     "vitest": "^4.1.8",
-    "react-router-dom": "^6.30.4"
+    "react-router-dom": "^6.30.4",
+    "react-dom": "16.14.0"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — validation PR for cloudscape-design/actions#124

Proves that actions#124 (pin the changed package's `github:#<ref>` deps to the PR commit in the dry-run) actually closes the coverage gap that let build-tools#55 through.

**What this PR does**
- Adds a deliberately-broken **required** peer `react-dom: ">=18.0.0"`. Consumers pin `react-dom@^16.14`, so this can only ERESOLVE if a consumer resolves build-tools from *this PR*.
- Points the dry-run at the actions self-test branch (`dry-run.yml@dev-gethinw-dryrun-git-ref-pin-selftest`), which carries #124's fix with all nested action refs repointed so the whole chain runs the fix.

**Expected result (proof)**
- Consumer dry-run jobs (Build components, collection-hooks, etc.) go **RED** with `ERESOLVE … peer react-dom@">=18.0.0" from @cloudscape-design/build-tools … github:cloudscape-design/build-tools#<this-PR-sha>` — the PR sha in the source confirms the repin fired.
- Against `actions@main` today the same PR would stay **GREEN** (consumers resolve build-tools from live `#main`, which has no such peer) — that's the blind spot #124 fixes.

Delete this branch and the actions self-test branch after validation.
